### PR TITLE
Make library into a distributable Python package.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,26 @@
+import setuptools
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="robotframework-datadriver",
+    version="0.0.1",
+    author="René Rohner(Snooz82)",
+    author_email="",
+    description="A library for data driven tests.",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/Snooz82/robotframework-datadriver",
+    package_dir={'':'src'},
+    packages=setuptools.find_packages('src'),
+    classifiers=[
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+        "Topic :: Software Development :: Testing",
+        "Topic :: Software Development :: Testing :: Acceptance",
+        "Framework :: Robot Framework",
+    ],
+)


### PR DESCRIPTION
Initial version of the setup.py file to make this a package. This
needs a review of values I have given to Author, Short Description, etc.
and some additional information, like author's email.

One can install this package as source locally and continue developement
using,

   pip install -e </path/to/root/directory>

or simply install the package using pip install </path/to/root/directory>

I am looking into installing both the library src and the examples. I would
suspect that, at least initially, people would want the example directory
so they thry out the library using those demos examples.