### PR TITLE
Workaround for test suite filtering by tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,8 @@ dmypy.json
 ### Python Patch ###
 .venv/
 CreatePiPWheel.bat
+
+.vscode/
+log.html
+output.xml
+report.html

--- a/example/Simple/FilterCases.robot
+++ b/example/Simple/FilterCases.robot
@@ -1,0 +1,15 @@
+*** Settings ***
+Documentation
+...  Simply filter the tags from the command line:
+...  robot --variable includeTag:lightweight FilterCases.robot
+Library  ${CURDIR}/../../src/DataDriver  Simple.csv  dialect=unix
+Test Template  Logger
+
+*** Test Cases ***
+Run  Default Message
+
+*** Keywords ***
+Logger
+    [Arguments]     ${message}
+    Log To Console  ${message}
+    Log To Console  ${TEST_TAGS}

--- a/example/Simple/FilterCases.robot
+++ b/example/Simple/FilterCases.robot
@@ -1,8 +1,10 @@
 *** Settings ***
 Documentation
 ...  Simply filter the tags from the command line:
-...  robot --variable includeTag:lightweight FilterCases.robot
-Library  ${CURDIR}/../../src/DataDriver  Simple.csv  dialect=unix
+...  robot --variable includeTags:lightweight FilterCases.robot
+
+Library  ${CURDIR}/../../src/DataDriver  Simple.csv  dialect=unix   include_tags=${includeTags}
+
 Test Template  Logger
 
 *** Test Cases ***

--- a/example/Simple/README.md
+++ b/example/Simple/README.md
@@ -3,10 +3,12 @@ Because it is often desirable to run just a subset of tests, it can be necessary
 
 The built-in `robot` command arguments `--include` and `--exclude` cannot be used for this purpose because they build the list of test cases to be executed prior to loading any libraries such as DataDriver.  Even the `--prerunmodifier` does not precede the build list, so the best approach is to avoid the use of the built-in filtering.
 
-Fortunately it is very straightforward to implement a simple filter for tags specified in the data by including one or more `--variable` arguments.  Each time the `includeTag` variable is set on the command line, the value will be used to apply a filter so that only rows with a tag in the `includeTag` filters will be executed.
+Fortunately it is very straightforward to implement a simple filter for tags specified in the data by including the --include_tags option when initializing the DataDriver library. The value supplied is a single string representing a comma-delimited list of tags to be included from the `[Tags]` field of the data. The tags are case-sensitive. The list will be used to apply a filter so that only rows with a tag in the included_tags filter will be executed.
+
+To determine these tags from the command line, use a `--variable` argument.  The `includeTag` variable is set on the command line, 
 
 ## Example:
-This illustrates how to use the tag filter feature with a single tag.
+This illustrates how to use the tag filter feature with two tags.
 
 ### Data file:
 |*** Test Cases ***|${message}|[Documentation]|[Tags]|
@@ -19,10 +21,8 @@ This illustrates how to use the tag filter feature with a single tag.
 ### Robot spec:
 ```robot
 *** Settings ***
-Documentation
-...  Simply filter the tags from the command line:
-...  robot --variable includeTag:lightweight FilterCases.robot
-Library  ${CURDIR}/../../src/DataDriver  Simple.csv  dialect=unix
+Library  ${CURDIR}/../../src/DataDriver  Simple.csv  dialect=unix   include_tags=${includeTags}
+
 Test Template  Logger
 
 *** Test Cases ***
@@ -33,10 +33,11 @@ Logger
     [Arguments]     ${message}
     Log To Console  ${message}
     Log To Console  ${TEST_TAGS}
+
 ```
 
 ### Command line:
-`robot --variable includeTag:lightweight FilterCases.robot`
+`robot --variable includeTags:lightweight,detailed FilterCases.robot`
 
 ### Output:
 ```
@@ -47,11 +48,16 @@ Second test :: Should be executed                                     With the t
 ['lightweight']
 Second test :: Should be executed                                     | PASS |
 ------------------------------------------------------------------------------
+Third test :: Should not be executed                                  Without a tag we want
+['detailed']
+Third test :: Should not be executed                                  | PASS |
+------------------------------------------------------------------------------
 Fourth test :: Should be executed because the tag is included in t... Includes a tag we want, and others
 ['and more', 'detailed', 'lightweight', 'more']
 Fourth test :: Should be executed because the tag is included in t... | PASS |
 ------------------------------------------------------------------------------
 FilterCases :: Simply filter the tags from the command line: robot... | PASS |
-2 critical tests, 2 passed, 0 failed
-2 tests total, 2 passed, 0 failed
+3 critical tests, 3 passed, 0 failed
+3 tests total, 3 passed, 0 failed
+==============================================================================
 ```

--- a/example/Simple/README.md
+++ b/example/Simple/README.md
@@ -1,0 +1,57 @@
+# Simple use case with tag filtering
+Because it is often desirable to run just a subset of tests, it can be necessary to use the filtering characteristic of test tags.
+
+The built-in `robot` command arguments `--include` and `--exclude` cannot be used for this purpose because they build the list of test cases to be executed prior to loading any libraries such as DataDriver.  Even the `--prerunmodifier` does not precede the build list, so the best approach is to avoid the use of the built-in filtering.
+
+Fortunately it is very straightforward to implement a simple filter for tags specified in the data by including one or more `--variable` arguments.  Each time the `includeTag` variable is set on the command line, the value will be used to apply a filter so that only rows with a tag in the `includeTag` filters will be executed.
+
+## Example:
+This illustrates how to use the tag filter feature with a single tag.
+
+### Data file:
+|*** Test Cases ***|${message}|[Documentation]|[Tags]|
+|----|----|----|---|
+|First test|Simple message with no tags|If there are some tags specified, this should not be executed||
+|Second test|With the tag we want|Should be executed|lightweight|
+|Third test|Without a tag we want|Should not be executed|detailed|
+|Fourth test|Includes a tag we want, and others|Should be executed because the tag is included in the list|detailed,lightweight,more,and more|
+
+### Robot spec:
+```robot
+*** Settings ***
+Documentation
+...  Simply filter the tags from the command line:
+...  robot --variable includeTag:lightweight FilterCases.robot
+Library  ${CURDIR}/../../src/DataDriver  Simple.csv  dialect=unix
+Test Template  Logger
+
+*** Test Cases ***
+Run  Default Message
+
+*** Keywords ***
+Logger
+    [Arguments]     ${message}
+    Log To Console  ${message}
+    Log To Console  ${TEST_TAGS}
+```
+
+### Command line:
+`robot --variable includeTag:lightweight FilterCases.robot`
+
+### Output:
+```
+==============================================================================
+FilterCases :: Simply filter the tags from the command line: robot --variab...
+==============================================================================
+Second test :: Should be executed                                     With the tag we want
+['lightweight']
+Second test :: Should be executed                                     | PASS |
+------------------------------------------------------------------------------
+Fourth test :: Should be executed because the tag is included in t... Includes a tag we want, and others
+['and more', 'detailed', 'lightweight', 'more']
+Fourth test :: Should be executed because the tag is included in t... | PASS |
+------------------------------------------------------------------------------
+FilterCases :: Simply filter the tags from the command line: robot... | PASS |
+2 critical tests, 2 passed, 0 failed
+2 tests total, 2 passed, 0 failed
+```

--- a/example/Simple/Simple.csv
+++ b/example/Simple/Simple.csv
@@ -1,0 +1,5 @@
+*** Test Cases ***,${message},[Documentation],[Tags]
+First test,Simple message with no tags,"If there are some tags specified, this should not be executed"
+Second test,With the tag we want,Should be executed, lightweight
+Third test,Without a tag we want,Should not be executed, detailed
+Fourth test,"Includes a tag we want, and others",Should be executed because the tag is included in the list,"detailed,lightweight,more,and more"

--- a/src/DataDriver/AbstractReaderClass.py
+++ b/src/DataDriver/AbstractReaderClass.py
@@ -85,7 +85,8 @@ class AbstractReaderClass:
         arguments = {}
         for arguments_column_id in self.arguments_column_ids:
             arguments[self.header[arguments_column_id]] = row[arguments_column_id]
-        tags = set([t.strip() for t in row[self.tags_column_id].split(',')] if self.tags_column_id and len(row) > self.tags_column_id else [])
+        # strip the spaces off of each tag in case the data uses them for readability
+        tags = [t.strip() for t in row[self.tags_column_id].split(',')] if self.tags_column_id and len(row) > self.tags_column_id else []
         documentation = row[self.documentation_column_id] if self.documentation_column_id else ''
 
         self.data_table.append(TestCaseData(test_case_name, arguments, tags, documentation))

--- a/src/DataDriver/AbstractReaderClass.py
+++ b/src/DataDriver/AbstractReaderClass.py
@@ -16,7 +16,6 @@
 from .ReaderConfig import ReaderConfig
 from .ReaderConfig import TestCaseData
 import re
-import sys
 
 
 class AbstractReaderClass:
@@ -40,9 +39,6 @@ class AbstractReaderClass:
         self.documentation_column_id = None
         self.header = []
         self.data_table = []
-        tag_prefix = "includeTag:"
-        tag_prefix_len = len(tag_prefix)
-        self.include_tags = set([t[tag_prefix_len:] for t in sys.argv if t.startswith(tag_prefix)])
 
         self.TESTCASE_TABLE_NAME = ReaderConfig.TEST_CASE_TABLE_NAME
         self.TEST_CASE_TABLE_PATTERN = r'(?i)^(\*+\s*test ?cases?[\s*].*)'
@@ -90,8 +86,6 @@ class AbstractReaderClass:
         for arguments_column_id in self.arguments_column_ids:
             arguments[self.header[arguments_column_id]] = row[arguments_column_id]
         tags = set([t.strip() for t in row[self.tags_column_id].split(',')] if self.tags_column_id and len(row) > self.tags_column_id else [])
-        if self.include_tags and not tags.intersection(self.include_tags):
-            return
         documentation = row[self.documentation_column_id] if self.documentation_column_id else ''
 
         self.data_table.append(TestCaseData(test_case_name, arguments, tags, documentation))

--- a/src/DataDriver/DataDriver.py
+++ b/src/DataDriver/DataDriver.py
@@ -706,7 +706,8 @@ Defaults:
                  sheet_name=0,
                  reader_class=None,
                  file_search_strategy='PATH',
-                 file_regex=f'(?i)(.*?)(\.csv)'
+                 file_regex=f'(?i)(.*?)(\.csv)',
+                 include_tags=None
                  ):
         """**Example:**
 
@@ -872,6 +873,9 @@ Usage in Robot Framework
         self.data_table = None
         self.index = None
         self.test_case_data = TestCaseData()
+        self.include_tags = None
+        if include_tags:
+            self.include_tags = set([t.strip() for t in include_tags.split(",")])
 
     def _start_suite(self, suite, result):
         """Called when a test suite starts.
@@ -888,6 +892,8 @@ Usage in Robot Framework
         self.template_keyword = self._get_template_keyword(suite)
         temp_test_list = list()
         for self.index, self.test_case_data in enumerate(self.data_table):
+            if self.include_tags and not set(self.test_case_data.tags).intersection(self.include_tags):
+                continue
             self._create_test_from_template()
             temp_test_list.append(self.test)
         suite.tests = temp_test_list


### PR DESCRIPTION
Unfortunately there is no api to intercept the command line filter. This workaround provides a simple way to get the job done.  Since the tags are determined solely from the command line args, there is no additional need to rely on the robot API.  The only side-effect is the existence of a hardwired variable defined in the run environment (named "includeTag") which may not serve any other purpose.