### PR TITLE
Allow other optional columns to the first column

### DIFF
--- a/atest/TestCases/first_col/documentation.csv
+++ b/atest/TestCases/first_col/documentation.csv
@@ -1,0 +1,3 @@
+[Documentation];${expected}
+Doc1;Doc1
+Doc2;Doc2

--- a/atest/TestCases/first_col/documentation.robot
+++ b/atest/TestCases/first_col/documentation.robot
@@ -1,0 +1,14 @@
+*** Settings ***
+Library           DataDriver    encoding=UTF8
+Test Template     Check
+
+
+*** Test Cases ***
+Documentation should be ${expected}
+
+
+*** Keywords ***
+Check
+    [Arguments]    ${expected}
+    log variables
+    Should Be Equal    ${TEST DOCUMENTATION}    ${expected}

--- a/atest/TestCases/first_col/tags.csv
+++ b/atest/TestCases/first_col/tags.csv
@@ -1,0 +1,3 @@
+[Tags];${expected}
+tag1;tag1
+tag2;tag2

--- a/atest/TestCases/first_col/tags.robot
+++ b/atest/TestCases/first_col/tags.robot
@@ -1,0 +1,13 @@
+*** Settings ***
+Library           DataDriver    encoding=UTF8
+Test Template     Check
+
+
+*** Test Cases ***
+Tags should containe ${expected}
+
+
+*** Keywords ***
+Check
+    [Arguments]    ${expected}
+    Should Be Equal    ${TEST TAGS}[0]    ${expected}

--- a/src/DataDriver/AbstractReaderClass.py
+++ b/src/DataDriver/AbstractReaderClass.py
@@ -112,10 +112,14 @@ class AbstractReaderClass(ABC):
                 )
         tags = (
             [t.strip() for t in row[self.tags_column_id].split(",")]
-            if self.tags_column_id
+            if self.tags_column_id is not None
             else None
         )
-        documentation = row[self.documentation_column_id] if self.documentation_column_id else ""
+        documentation = (
+            row[self.documentation_column_id]
+            if self.documentation_column_id is not None
+            else ""
+        )
 
         self.data_table.append(TestCaseData(test_case_name, arguments, tags, documentation))
 


### PR DESCRIPTION
This PR would allow having `[Tags]` or `[Documentation]` columns as a first column in the data source.