### PR TITLE
fix rerun failed bug

### DIFF
--- a/src/DataDriver/rerunfailed.py
+++ b/src/DataDriver/rerunfailed.py
@@ -19,7 +19,7 @@ class rerunfailed(SuiteVisitor):
 
     def start_suite(self, suite):
         """Remove tests that match the given pattern."""
-        if self.has_no_tests(suite.name):
+        if self.has_no_tests(suite.longname):
             suite.tests.clear()
             return
         if self._suite_is_data_driven(suite):
@@ -27,7 +27,7 @@ class rerunfailed(SuiteVisitor):
             suite.resource.variables.append(dynamic_tests)
         else:
             suite.tests = [
-                t for t in suite.tests if f"{t.parent.name}.{t.name}" in self._failed_tests
+                t for t in suite.tests if t.longname in self._failed_tests
             ]
 
     def has_no_tests(self, name):
@@ -54,4 +54,4 @@ class DataDriverResultsVisitor(ResultVisitor):
 
     def start_test(self, test):
         if test.status == "FAIL":
-            self.failed_tests.append(f"{test.parent.name}.{test.name}")
+            self.failed_tests.append(test.longname)


### PR DESCRIPTION
[example.pdf](https://github.com/Snooz82/robotframework-datadriver/files/12366159/example.pdf)
Run test with this example:
`robot .`
there will be 3 failed tests

then rerun the failed tests with command:
`robot --prerunmodifier DataDriver.rerunfailed:output.xml --output rerun.xml .`

4 tests will be reran.

there's one passed test "example.test.tc1" is incorrectly selected due to the same name with the real failed test.

We should use test longname instead of the partial name to match the failed test