### PR TITLE
Add `generic json reader`

### DIFF
--- a/atest/TestCases/custom_reader/generic_json_reader.robot
+++ b/atest/TestCases/custom_reader/generic_json_reader.robot
@@ -1,0 +1,20 @@
+*** Settings ***
+Library    DataDriver    file=data.json   reader_class=generic_json_reader
+Test Template    log vars
+
+Test Tags    json
+
+
+*** Test Cases ***
+${test_case_name}   1    2
+
+
+*** Keywords ***
+log vars
+    [Arguments]    ${arguments}    ${tags}
+    Should Not Be Empty    ${tags}    Failed to load tags from test case data.
+    Set Tags    @{tags}
+    Should Not Be Empty    ${arguments}    Failed to load arguments from test case data.
+    Log To Console    \${argumentes}: ${arguments}
+    Log To Console    username: ${arguments}[\${username}]
+    Log To Console    password: ${arguments}[\${password}]

--- a/src/DataDriver/generic_json_reader.py
+++ b/src/DataDriver/generic_json_reader.py
@@ -1,0 +1,47 @@
+# Copyright 2018-  René Rohner
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from DataDriver.AbstractReaderClass import (
+    AbstractReaderClass,
+)
+from DataDriver.ReaderConfig import (
+    TestCaseData,
+)
+
+from pathlib import Path
+import json
+
+
+class generic_json_reader(AbstractReaderClass):
+    """
+    Generate TestCaseData from any JSON file.
+
+    Useful when working on normalized structured data provided by APIs.
+
+    Requires JSON file to be a list.
+    """
+
+    def get_data_from_source(
+        self,
+    ) -> list[TestCaseData]:
+        file_path = Path(self.file)
+        with file_path.open(encoding=self.csv_encoding) as json_file:
+            json_data = json.load(json_file)
+
+        if not isinstance(json_data, list):
+            raise TypeError(f"Cannot generate test data. Data in {file_path} is not a list.")
+
+        return [
+            TestCaseData(arguments={f"${{{k}}}": v for k, v in data.items()}) for data in json_data
+        ]


### PR DESCRIPTION
Closes #98 

This PR adds a simple json-reader creating test data from any JSON file.

The use case is data provided by APIs that is structured and well formatted. For using it with the original json-reader someone would have to put it in the _Test Case Name_ - _Tags_ - _Arguments_ format which is complicated to automate. For working with not-explicit test data, the generic json reader is more flexible.