### PR TITLE
add line numbers to the newly created test cases

### DIFF
--- a/src/DataDriver/DataDriver.py
+++ b/src/DataDriver/DataDriver.py
@@ -1863,7 +1863,8 @@ When DataDriver is used together with Pabot, it optimizes the ``--testlevelsplit
         self.test.setup = self.template_test.setup
         self.test.teardown = self.template_test.teardown
         self.test.body.create_keyword(
-            name=self.template_keyword.name, args=self._get_template_arguments()
+            name=self.template_keyword.name, args=self._get_template_arguments(),
+            lineno=self.template_test.lineno,
         )
 
     def _get_template_arguments(self):


### PR DESCRIPTION
this PR adds linenumbers to the virtually created tests cases, so that robotcode can show the correct line number in the debugger.